### PR TITLE
DM-32976: Use copy instead of copy2.

### DIFF
--- a/python/lsst/resources/file.py
+++ b/python/lsst/resources/file.py
@@ -260,8 +260,10 @@ class FileResourcePath(ResourcePath):
                     pass
 
             if transfer == "move":
-                with transaction.undoWith(f"move from {local_src}", shutil.move, newFullPath, local_src):
-                    shutil.move(local_src, newFullPath)
+                with transaction.undoWith(
+                    f"move from {local_src}", shutil.move, newFullPath, local_src, copy_function=shutil.copy
+                ):
+                    shutil.move(local_src, newFullPath, copy_function=shutil.copy)
             elif transfer == "copy":
                 with transaction.undoWith(f"copy from {local_src}", os.remove, newFullPath):
                     shutil.copy(local_src, newFullPath)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
