### PR TITLE
DM-34188: Use Client.bucket and not Client.get_bucket

### DIFF
--- a/python/lsst/resources/gs.py
+++ b/python/lsst/resources/gs.py
@@ -134,7 +134,7 @@ class GSResourcePath(ResourcePath):
     @property
     def bucket(self) -> storage.Bucket:
         if self._bucket is None:
-            self._bucket = self.client.get_bucket(self.netloc, retry=_RETRY_POLICY)
+            self._bucket = self.client.bucket(self.netloc)
         return self._bucket
 
     @property


### PR DESCRIPTION
Deriving Blobs from a bucket obtained by get_bucket seems
to require more permissions than using a blob obtained
from Client.bucket().

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
