### PR TITLE
DM-34135: Fix docstring for ResourcePath.transfer_from.

### DIFF
--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -1077,7 +1077,7 @@ class ResourcePath:
         overwrite: bool = False,
         transaction: Optional[TransactionProtocol] = None,
     ) -> None:
-        """Transfer the current resource to a new location.
+        """Transfer another resource to this location.
 
         Parameters
         ----------


### PR DESCRIPTION
The previous docstring implied `transfer_from` did the exact opposite of what it does.