### PR TITLE
DM-34610: Disable flake8 N818 for faked exceptions.

### DIFF
--- a/python/lsst/resources/gs.py
+++ b/python/lsst/resources/gs.py
@@ -39,19 +39,19 @@ except ImportError:
     class ClientError(Exception):
         pass
 
-    class NotFound(ClientError):  # type: ignore
+    class NotFound(ClientError):  # type: ignore  # noqa: N818
         pass
 
-    class TooManyRequests(ClientError):  # type: ignore
+    class TooManyRequests(ClientError):  # type: ignore  # noqa: N818
         pass
 
     class InternalServerError(ClientError):  # type: ignore
         pass
 
-    class BadGateway(ClientError):  # type: ignore
+    class BadGateway(ClientError):  # type: ignore  # noqa: N818
         pass
 
-    class ServiceUnavailable(ClientError):  # type: ignore
+    class ServiceUnavailable(ClientError):  # type: ignore  # noqa: N818
         pass
 
 


### PR DESCRIPTION
This is fallout from the change to flake8 4.0 with pep8-naming 0.12.1.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
