### PR TITLE
DM-35690: Require pip version less than 22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Update pip/wheel infrastructure
         shell: bash -l {0}
         run: |
-          conda install -y -q pip wheel
+          conda install -y -q "pip<22" wheel
 
       - name: Install cryptography package for moto
         shell: bash -l {0}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip<22"
           pip install --upgrade setuptools wheel build
 
       - name: Build and create distribution


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
