### PR TITLE
DM-38552: Support non-file root in constructor for relative paths

### DIFF
--- a/doc/changes/DM-38552.feature.rst
+++ b/doc/changes/DM-38552.feature.rst
@@ -1,0 +1,2 @@
+* Modified the way that a schemeless absolute URI behaves such that we now always convert it to a ``file`` URI.
+* The ``root`` parameter can now use any ``ResourcePath`` scheme such that a relative URI can be treated as a URI relative to, for example, a S3 or WebDAV root.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,3 +126,13 @@ convention = "numpy"
 # D200, D205 and D400 all complain if the first sentence of the docstring does
 # not fit on one line.
 add-ignore = ["D107", "D105", "D102", "D100", "D200", "D205", "D400"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -85,11 +85,14 @@ class ResourcePath:
     root : `str` or `ResourcePath`, optional
         When fixing up a relative path in a ``file`` scheme or if scheme-less,
         use this as the root. Must be absolute.  If `None` the current
-        working directory will be used. Can be a file URI.
+        working directory will be used. Can be a file URI. Not used if
+        ``forceAbsolute`` is `False`.
     forceAbsolute : `bool`, optional
         If `True`, scheme-less relative URI will be converted to an absolute
         path using a ``file`` scheme. If `False` scheme-less URI will remain
-        scheme-less and will not be updated to ``file`` or absolute path.
+        scheme-less and will not be updated to ``file`` or absolute path unless
+        it is already an absolute path, in which case it will be updated to
+        a ``file`` scheme.
     forceDirectory: `bool`, optional
         If `True` forces the URI to end with a separator, otherwise given URI
         is interpreted as is.

--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -748,7 +748,9 @@ class ResourcePath:
             return None
         if self.netloc != other.netloc:
             # Special case for localhost vs empty string.
-            if {self.netloc, other.netloc} != {"", "localhost"}:
+            # There can be many variants of localhost.
+            local_netlocs = {"", "localhost", "localhost.localdomain", "127.0.0.1"}
+            if not {self.netloc, other.netloc}.issubset(local_netlocs):
                 return None
 
         enclosed_path = self._pathLib(self.relativeToPathRoot)

--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -100,6 +100,11 @@ class ResourcePath:
         If `True` indicates that this URI points to a temporary resource.
         The default is `False`, unless ``uri`` is already a `ResourcePath`
         instance and ``uri.isTemporary is True``.
+
+    Notes
+    -----
+    A non-standard URI of the form ``file:dir/file.txt`` is always converted
+    to an absolute ``file`` URI.
     """
 
     _pathLib: Type[PurePath] = PurePosixPath

--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -80,13 +80,13 @@ class ResourcePath:
     Parameters
     ----------
     uri : `str`, `Path`, `urllib.parse.ParseResult`, or `ResourcePath`.
-        URI in string form.  Can be scheme-less if referring to a local
-        filesystem path.
+        URI in string form.  Can be scheme-less if referring to a relative
+        path or an absolute path on the local file system.
     root : `str` or `ResourcePath`, optional
         When fixing up a relative path in a ``file`` scheme or if scheme-less,
         use this as the root. Must be absolute.  If `None` the current
-        working directory will be used. Can be a file URI. Not used if
-        ``forceAbsolute`` is `False`.
+        working directory will be used. Can be any supported URI scheme.
+        Not used if ``forceAbsolute`` is `False`.
     forceAbsolute : `bool`, optional
         If `True`, scheme-less relative URI will be converted to an absolute
         path using a ``file`` scheme. If `False` scheme-less URI will remain

--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -266,6 +266,10 @@ class ResourcePath:
                     # fragments since join() will drop them.
                     parsed = parsed._replace(scheme=joined.scheme, path=joined.path, netloc=joined.netloc)
                     subclass = type(joined)
+
+                    # Clear the root parameter to indicate that it has
+                    # been applied already.
+                    root_uri = None
                 else:
                     from .schemeless import SchemelessResourcePath
 

--- a/python/lsst/resources/file.py
+++ b/python/lsst/resources/file.py
@@ -386,7 +386,7 @@ class FileResourcePath(ResourcePath):
     def _fixupPathUri(
         cls,
         parsed: urllib.parse.ParseResult,
-        root: Optional[Union[str, ResourcePath]] = None,
+        root: Optional[ResourcePath] = None,
         forceAbsolute: bool = False,
         forceDirectory: bool = False,
     ) -> Tuple[urllib.parse.ParseResult, bool]:
@@ -396,11 +396,10 @@ class FileResourcePath(ResourcePath):
         ----------
         parsed : `~urllib.parse.ParseResult`
             The result from parsing a URI using `urllib.parse`.
-        root : `str` or `ResourcePath`, optional
+        root : `ResourcePath`, optional
             Path to use as root when converting relative to absolute.
-            If `None`, it will be the current working directory. This
-            is a local file system path, or a file URI.  It is only used if
-            a file-scheme is used incorrectly with a relative path.
+            If `None`, it will be the current working directory. It is only
+            used if a file-scheme is used incorrectly with a relative path.
         forceAbsolute : `bool`, ignored
             Has no effect for this subclass. ``file`` URIs are always
             absolute.
@@ -455,13 +454,13 @@ class FileResourcePath(ResourcePath):
         replacements = {}
 
         if root is None:
-            root = os.path.abspath(os.path.curdir)
-        elif isinstance(root, ResourcePath):
+            root_str = os.path.abspath(os.path.curdir)
+        else:
             if root.scheme and root.scheme != "file":
                 raise RuntimeError(f"The override root must be a file URI not {root.scheme}")
-            root = os.path.abspath(root.ospath)
+            root_str = os.path.abspath(root.ospath)
 
-        replacements["path"] = posixpath.normpath(posixpath.join(os2posix(root), parsed.path))
+        replacements["path"] = posixpath.normpath(posixpath.join(os2posix(root_str), parsed.path))
 
         # normpath strips trailing "/" so put it back if necessary
         # Acknowledge that trailing separator exists.

--- a/python/lsst/resources/schemeless.py
+++ b/python/lsst/resources/schemeless.py
@@ -205,8 +205,12 @@ class SchemelessResourcePath(FileResourcePath):
                 # so we trust the user.
                 root_str = os.path.abspath(root.ospath)
 
-            # This can stay in OS path form, do not change to file
-            # scheme.
+            # Convert to "file" scheme to make it consistent with the above
+            # decision. It makes no sense for sometimes an absolute path
+            # to be a file URI and sometimes for it not to be.
+            replacements["scheme"] = "file"
+
+            # Keep in OS form for now.
             replacements["path"] = os.path.normpath(os.path.join(root_str, expandedPath))
         else:
             # No change needed for relative local path staying relative

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -389,8 +389,9 @@ class GenericTestCase(_GenericTestCase):
         )
         self.assertEqual(joined, ResourcePath(f"{self.root}hsc/payload/test.qgraph"))
 
-        with self.assertRaises(ValueError):
-            ResourcePath(f"{self.root}hsc/payload/").join(ResourcePath("test.qgraph"))
+        qgraph = ResourcePath("test.qgraph")  # Absolute URI
+        joined = ResourcePath(f"{self.root}hsc/payload/").join(qgraph)
+        self.assertEqual(joined, qgraph)
 
     def test_quoting(self) -> None:
         """Check that quoting works."""

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -65,12 +65,6 @@ class FileTestCase(GenericTestCase, unittest.TestCase):
         via_root = ResourcePath("b.txt", root=root)
         self.assertEqual(via_root.ospath, "/root/b.txt")
 
-        with self.assertRaises(ValueError):
-            # Scheme-less URIs are not allowed to support non-file roots
-            # at the present time. This may change in the future to become
-            # equivalent to ResourcePath.join()
-            ResourcePath("a/b.txt", root=ResourcePath("s3://bucket/a/b/"))
-
 
 class FileReadWriteTestCase(GenericReadWriteTestCase, unittest.TestCase):
     scheme = "file"

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -38,9 +38,9 @@ class LocationTestCase(unittest.TestCase):
         # 1) no determinable schemes (ensures schema and netloc are not set)
         osRelFilePath = os.path.join(testRoot, "relative/file.ext")
         uriStrings = [
-            ("relative/file.ext", True, False, "", "", osRelFilePath),
+            ("relative/file.ext", True, False, "file", "", osRelFilePath),
             ("relative/file.ext", False, False, "", "", "relative/file.ext"),
-            ("test/../relative/file.ext", True, False, "", "", osRelFilePath),
+            ("test/../relative/file.ext", True, False, "file", "", osRelFilePath),
             ("test/../relative/file.ext", False, False, "", "", "relative/file.ext"),
             ("relative/dir", False, True, "", "", "relative/dir/"),
         ]
@@ -106,10 +106,11 @@ class LocationTestCase(unittest.TestCase):
         # test root becomes abspath(".") when not specified, note specific
         # file:// scheme case
         uriStrings = (
+            # URI, forceAbsolute, forceDirectory, scheme, netloc, path
             ("file://relative/file.ext", True, False, "file", "relative", "/file.ext"),
             ("file:relative/file.ext", False, False, "file", "", os.path.abspath("relative/file.ext")),
             ("file:relative/dir/", True, True, "file", "", os.path.abspath("relative/dir") + "/"),
-            ("relative/file.ext", True, False, "", "", os.path.abspath("relative/file.ext")),
+            ("relative/file.ext", True, False, "file", "", os.path.abspath("relative/file.ext")),
         )
 
         for uriInfo in uriStrings:
@@ -133,12 +134,12 @@ class LocationTestCase(unittest.TestCase):
             with self.subTest(uri=uriInfo[0]):
                 self.assertEqual(uri.path, uriInfo[2])
 
-        # Check that schemeless can become file scheme
+        # Check that schemeless can become file scheme.
         schemeless = ResourcePath("relative/path.ext")
         filescheme = ResourcePath("/absolute/path.ext")
-        self.assertFalse(schemeless.scheme)
+        self.assertEqual(schemeless.scheme, "file")
         self.assertEqual(filescheme.scheme, "file")
-        self.assertNotEqual(type(schemeless), type(filescheme))
+        self.assertEqual(type(schemeless), type(filescheme))
 
         # Copy constructor
         uri = ResourcePath("s3://amazon/datastore", forceDirectory=True)

--- a/tests/test_schemeless.py
+++ b/tests/test_schemeless.py
@@ -27,34 +27,34 @@ class SchemelessTestCase(unittest.TestCase):
         self.assertFalse(relative_uri.isabs())
         self.assertEqual(relative_uri.ospath, relative)
 
-        # This will be a schemeless absolute URI.
-        # It is not converted to a file URI (but maybe should be).
+        # Converted to a file URI.
         abs_uri = ResourcePath(relative, forceAbsolute=True)
-        self.assertFalse(abs_uri.scheme)
+        self.assertEqual(abs_uri.scheme, "file")
         self.assertTrue(abs_uri.isabs())
 
-        # For historical reasons an absolute path is converted
-        # to a file URI.
+        # An absolute path is converted to a file URI.
         file_uri = ResourcePath(abspath)
         self.assertEqual(file_uri.scheme, "file")
         self.assertTrue(file_uri.isabs())
 
         # Use a prefix root.
-        # This will remain schemeless.
         prefix = "/a/b/"
         abs_uri = ResourcePath(relative, root=prefix)
         self.assertEqual(abs_uri.ospath, f"{prefix}{relative}")
-        self.assertEqual(abs_uri.scheme, "")
+        self.assertEqual(abs_uri.scheme, "file")
 
-        # Only the path is used.
+        # Use a file prefix.
         prefix = "file://localhost/a/b/"
         prefix_uri = ResourcePath(prefix)
         file_uri = ResourcePath(relative, root=prefix_uri)
-        self.assertEqual(str(file_uri), f"{prefix_uri.ospath}{relative}")
+        self.assertEqual(str(file_uri), f"file://{prefix_uri.ospath}{relative}")
 
         # Fragments should be fine.
         relative_uri = ResourcePath(relative + "#frag", forceAbsolute=False)
         self.assertEqual(str(relative_uri), f"{relative}#frag")
+
+        file_uri = ResourcePath(relative + "#frag", root=prefix_uri)
+        self.assertEqual(str(file_uri), f"file://{prefix_uri.ospath}{relative}#frag")
 
         # For historical reasons a a root can not be anything other
         # than a file. This does not really make sense in the general


### PR DESCRIPTION
Also fix the strange behavior where absolute schemeless URIs can sometimes be updated to `file` URIs but not always.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
