### PR TITLE
DM-38589: Fix repeated reads with stream handle

### DIFF
--- a/doc/changes/DM-38589.bugfix.rst
+++ b/doc/changes/DM-38589.bugfix.rst
@@ -1,0 +1,2 @@
+* Fix EOF detection with S3 and HTTP resource handles when using repeated ``read()``.
+* Ensure that HTTP reads with resource handles using byte ranges correctly disable remote compression.

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -152,5 +152,5 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
             self._completeBuffer.seek(0)
             return self.read(size=size)
 
-        self._current_position += size
+        self._current_position += len(resp.content)
         return resp.content

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -140,7 +140,8 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
 
         if (code := resp.status_code) not in (200, 206):
             raise FileNotFoundError(
-                f"Unable to read resource {self._url}, or bytes are out of range; status code: {code}"
+                f"Unable to read resource {self._url}, or byte request {self._current_position}-{end_pos}"
+                f" is out of range; status code: {code}"
             )
 
         # verify this is not actually the whole file and the server did not lie

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -181,14 +181,17 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
         # server.
         if "Content-Range" in resp.headers:
             content_range = resp.headers["Content-Range"]
-            _, range_string = content_range.split(" ")
-            range, total = range_string.split("/")
-            if "-" in range:
-                _, end = range.split("-")
-                end_pos = int(end)
-                if total != "*":
-                    if end_pos == int(total) - 1:
-                        self._eof = True
+            units, range_string = content_range.split(" ")
+            if units == "bytes":
+                range, total = range_string.split("/")
+                if "-" in range:
+                    _, end = range.split("-")
+                    end_pos = int(end)
+                    if total != "*":
+                        if end_pos == int(total) - 1:
+                            self._eof = True
+            else:
+                self._log.warning("Requested byte range from server but instead got: %s", content_range)
 
         # Try to guess that we overran the end. This will not help if we
         # read exactly the number of bytes to get us to the end and so we

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -50,10 +50,12 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
 
         self._closed = CloseStatus.OPEN
         self._current_position = 0
+        self._eof = False
 
     def close(self) -> None:
         self._closed = CloseStatus.CLOSED
         self._completeBuffer = None
+        self._eof = True
 
     @property
     def closed(self) -> bool:
@@ -81,6 +83,7 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
         raise io.UnsupportedOperation("HttpReadResourceHandles Do not support line by line reading")
 
     def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        self._eof = False
         if whence == io.SEEK_CUR and (self._current_position + offset) >= 0:
             self._current_position += offset
         elif whence == io.SEEK_SET and offset >= 0:
@@ -112,6 +115,10 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
         raise io.UnsupportedOperation("HttpReadResourceHandles are read only")
 
     def read(self, size: int = -1) -> bytes:
+        if self._eof:
+            # At EOF so always return an empty byte string.
+            return b""
+
         # branch for if the complete file has been read before
         if self._completeBuffer is not None:
             result = self._completeBuffer.read(size)
@@ -147,18 +154,47 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
         ):
             resp = self._session.get(self._url, stream=False, timeout=self._timeout, headers=headers)
 
+        if resp.status_code == 416:
+            # Must have run off the end of the file. A standard file handle
+            # will treat this as EOF so be consistent with that. Do not change
+            # the current position.
+            self._eof = True
+            return b""
+
         if (code := resp.status_code) not in (200, 206):
             raise FileNotFoundError(
                 f"Unable to read resource {self._url}, or bytes are out of range; status code: {code}"
             )
 
+        len_content = len(resp.content)
+
         # verify this is not actually the whole file and the server did not lie
         # about supporting ranges
-        if len(resp.content) > size or code != 206:
+        if len_content > size or code != 206:
             self._completeBuffer = io.BytesIO()
             self._completeBuffer.write(resp.content)
             self._completeBuffer.seek(0)
             return self.read(size=size)
 
-        self._current_position += len(resp.content)
+        # The response header should tell us the total number of bytes
+        # in the file and also the current position we have got to in the
+        # server.
+        if "Content-Range" in resp.headers:
+            content_range = resp.headers["Content-Range"]
+            _, range_string = content_range.split(" ")
+            range, total = range_string.split("/")
+            if "-" in range:
+                _, end = range.split("-")
+                end_pos = int(end)
+                if total != "*":
+                    if end_pos == int(total) - 1:
+                        self._eof = True
+
+        # Try to guess that we overran the end. This will not help if we
+        # read exactly the number of bytes to get us to the end and so we
+        # will need to do one more read and get a 416.
+        if len_content < size:
+            self._eof = True
+
+        self._current_position += len_content
         return resp.content

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -50,8 +50,6 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
 
         self._closed = CloseStatus.OPEN
         self._current_position = 0
-        self._maximumSize: int | None = None
-        self._recursing = False
 
     def close(self) -> None:
         self._closed = CloseStatus.CLOSED
@@ -131,9 +129,6 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
 
             return self._completeBuffer.getbuffer().tobytes()
 
-        if self._maximumSize is not None and self._current_position >= self._maximumSize:
-            return b""
-
         # a partial read is required, either because a size has been specified,
         # or a read has previously been done.
 
@@ -143,30 +138,18 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
         with time_this(self._log, msg="Read from remote resource %s", args=(self._url,)):
             resp = self._session.get(self._url, stream=False, timeout=self._timeout, headers=headers)
 
-        match (code := resp.status_code):
-            case 206 | 200:
-                # verify this is not actually the whole file and the server
-                # did not lie about supporting ranges
-                if len(resp.content) > size or code != 206:
-                    self._completeBuffer = io.BytesIO()
-                    self._completeBuffer.write(resp.content)
-                    self._completeBuffer.seek(0)
-                    return self.read(size=size)
+        if (code := resp.status_code) not in (200, 206):
+            raise FileNotFoundError(
+                f"Unable to read resource {self._url}, or bytes are out of range; status code: {code}"
+            )
 
-                self._current_position += size
-                result = resp.content
-            case 416:
-                if self._recursing:
-                    # The function has already tried to read the whole range
-                    # and failed a second time, which means the maximum position
-                    # is where the file already is
-                    return b""
-                # Read the rest of the file
-                self._recursing = True
-                result = self.read()
-                self._maximumSize = self._current_position
-                self._recursing = False
-            case _:
-                raise BufferError(f"There was a problem reading the buffer with code {code}")
+        # verify this is not actually the whole file and the server did not lie
+        # about supporting ranges
+        if len(resp.content) > size or code != 206:
+            self._completeBuffer = io.BytesIO()
+            self._completeBuffer.write(resp.content)
+            self._completeBuffer.seek(0)
+            return self.read(size=size)
 
-        return result
+        self._current_position += len(resp.content)
+        return resp.content

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -63,7 +63,9 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
         raise io.UnsupportedOperation("HttpReadResourceHandle does not have a file number")
 
     def flush(self) -> None:
-        raise io.UnsupportedOperation("HttpReadResourceHandles are read only")
+        modes = set(self._mode)
+        if {"w", "x", "a", "+"} & modes:
+            raise io.UnsupportedOperation("HttpReadResourceHandles are read only")
 
     @property
     def isatty(self) -> Union[bool, Callable[[], bool]]:

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -188,7 +188,7 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
                     _, end = range.split("-")
                     end_pos = int(end)
                     if total != "*":
-                        if end_pos == int(total) - 1:
+                        if end_pos >= int(total) - 1:
                             self._eof = True
             else:
                 self._log.warning("Requested byte range from server but instead got: %s", content_range)

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -131,13 +131,20 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
 
             return self._completeBuffer.getbuffer().tobytes()
 
-        # a partial read is required, either because a size has been specified,
-        # or a read has previously been done.
+        # A partial read is required, either because a size has been specified,
+        # or a read has previously been done. Any time we specify a byte range
+        # we must disable the gzip compression on the server since we want
+        # to address ranges in the uncompressed file. If we send ranges that
+        # are interpreted by the server as offsets into the compressed file
+        # then that is at least confusing and also there is no guarantee that
+        # the bytes can be uncompressed.
 
         end_pos = self._current_position + (size - 1) if size >= 0 else ""
-        headers = {"Range": f"bytes={self._current_position}-{end_pos}"}
+        headers = {"Range": f"bytes={self._current_position}-{end_pos}", "Accept-Encoding": "identity"}
 
-        with time_this(self._log, msg="Read from remote resource %s", args=(self._url,)):
+        with time_this(
+            self._log, msg="Read from remote resource %s using headers %s", args=(self._url, headers)
+        ):
             resp = self._session.get(self._url, stream=False, timeout=self._timeout, headers=headers)
 
         if (code := resp.status_code) not in (200, 206):

--- a/python/lsst/resources/_resourceHandles/_s3ResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_s3ResourceHandle.py
@@ -274,7 +274,7 @@ class S3ResourceHandle(BaseResourceHandle[bytes]):
             response = self._client.get_object(Bucket=self._bucket, Key=self._key, **args)
             contents = response["Body"].read()
             response["Body"].close()
-            self._position = len(contents)
+            self._position += len(contents)
             return contents
         except ClientError as exc:
             if exc.response["ResponseMetadata"]["HTTPStatusCode"] == 416:

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -93,6 +93,9 @@ def _check_open(
             test_case.assertEqual(len(bytes_read), 0)
             bytes_read = read_buffer.read(size)
             test_case.assertEqual(len(bytes_read), 0)
+            read_buffer.seek(0)
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(bytes_read, content)
         # Write two copies of the content, overwriting the single copy there.
         with uri.open("w" + mode_suffix, **kwargs) as write_buffer:
             write_buffer.write(double_content)

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -84,6 +84,15 @@ def _check_open(
         # Read the file we created and check the contents.
         with uri.open("r" + mode_suffix, **kwargs) as read_buffer:
             test_case.assertEqual(read_buffer.read(), content)
+        # Check that we can read bytes in a loop and get EOF
+        with uri.open("r" + mode_suffix, **kwargs) as read_buffer:
+            size = len(bytes_content) * 3
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(bytes_read, content)
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(len(bytes_read), 0)
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(len(bytes_read), 0)
         # Write two copies of the content, overwriting the single copy there.
         with uri.open("w" + mode_suffix, **kwargs) as write_buffer:
             write_buffer.write(double_content)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -171,6 +171,9 @@ class HttpReadWriteWebdavTestCase(GenericReadWriteTestCase, unittest.TestCase):
             self.assertIsNotNone(handle._completeBuffer)
             self.assertEqual(result, contents)
 
+            # Check that flush works on read-only handle.
+            handle.flush()
+
         # Verify reading as a string handle works as expected.
         with remote_file.open("r") as handle:
             self.assertIsInstance(handle, io.TextIOWrapper)
@@ -181,6 +184,9 @@ class HttpReadWriteWebdavTestCase(GenericReadWriteTestCase, unittest.TestCase):
             # Check if string methods work.
             result = handle.read()
             self.assertEqual(result, contents)
+
+            # Check that flush works on read-only handle.
+            handle.flush()
 
         # Verify that write modes invoke the default base method
         with remote_file.open("w") as handle:


### PR DESCRIPTION
This works around a bug found in wsgidav where reading byte ranges past the end of file return the entire file contents and not 416 status code (see mar10/wsgidav#281).

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
