### PR TITLE
DM-38552: (hotfix) Protect test against special characters in parent directories

### DIFF
--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -118,7 +118,9 @@ class LocationTestCase(unittest.TestCase):
             with self.subTest(in_uri=uriInfo[0], out_uri=uri):
                 self.assertEqual(uri.scheme, uriInfo[3], "test scheme")
                 self.assertEqual(uri.netloc, uriInfo[4], "test netloc")
-                self.assertEqual(uri.path, uriInfo[5], "test path")
+                # Use ospath here to ensure that we have unquoted any
+                # special characters in the parent directories.
+                self.assertEqual(uri.ospath, uriInfo[5], "test path")
 
         # File replacement
         uriStrings = (

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -98,7 +98,7 @@ class LocationTestCase(unittest.TestCase):
 
         for uriInfo in uriStrings:
             uri = ResourcePath(uriInfo[0], root=testRoot, forceAbsolute=uriInfo[1], forceDirectory=uriInfo[2])
-            with self.subTest(uri=uriInfo[0]):
+            with self.subTest(in_uri=uriInfo[0], out_uri=uri):
                 self.assertEqual(uri.scheme, uriInfo[3], "test scheme")
                 self.assertEqual(uri.netloc, uriInfo[4], "test netloc")
                 self.assertEqual(uri.path, uriInfo[5], "test path")
@@ -115,7 +115,7 @@ class LocationTestCase(unittest.TestCase):
 
         for uriInfo in uriStrings:
             uri = ResourcePath(uriInfo[0], forceAbsolute=uriInfo[1], forceDirectory=uriInfo[2])
-            with self.subTest(uri=uriInfo[0]):
+            with self.subTest(in_uri=uriInfo[0], out_uri=uri):
                 self.assertEqual(uri.scheme, uriInfo[3], "test scheme")
                 self.assertEqual(uri.netloc, uriInfo[4], "test netloc")
                 self.assertEqual(uri.path, uriInfo[5], "test path")
@@ -131,7 +131,7 @@ class LocationTestCase(unittest.TestCase):
 
         for uriInfo in uriStrings:
             uri = ResourcePath(uriInfo[0], forceAbsolute=False).updatedFile(uriInfo[1])
-            with self.subTest(uri=uriInfo[0]):
+            with self.subTest(in_uri=uriInfo[0], out_uri=uri):
                 self.assertEqual(uri.path, uriInfo[2])
 
         # Check that schemeless can become file scheme.


### PR DESCRIPTION
With the recent change where absolute path schemeless URIs becomes file URIs, we end up with the possibility of there being url encoding of the path. To protect against that we switch to testing against ospath since these are all file paths,

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
