### PR TITLE
DM-38599: Fix contents length checking in server-encoded HTTP responses

### DIFF
--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -1521,7 +1521,7 @@ def _parse_propfind_response_body(body: str) -> List[DavProperty]:
         return responses
     else:
         # Could not parse the body
-        raise ValueError(f"Unable to parse response for PROPFIND request: {response}")
+        raise ValueError(f"Unable to parse response for PROPFIND request: {body}")
 
 
 class DavProperty:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
