### PR TITLE
DM-38589: (Alternative) Fix EOF for HTTP file handle

### DIFF
--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -152,5 +152,5 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
             self._completeBuffer.seek(0)
             return self.read(size=size)
 
-        self._current_position += size
+        self._current_position += len(resp.content)
         return resp.content

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -63,7 +63,11 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
         raise io.UnsupportedOperation("HttpReadResourceHandle does not have a file number")
 
     def flush(self) -> None:
-        raise io.UnsupportedOperation("HttpReadResourceHandles are read only")
+        modes = set(self._mode.split())
+        if {"w", "x", "a", "+"} & modes:
+            raise io.UnsupportedOperation("HttpReadResourceHandles are read only")
+        if self._completeBuffer is not None:
+            self._completeBuffer.flush()
 
     @property
     def isatty(self) -> Union[bool, Callable[[], bool]]:

--- a/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_httpResourceHandle.py
@@ -140,7 +140,8 @@ class HttpReadResourceHandle(BaseResourceHandle[bytes]):
 
         if (code := resp.status_code) not in (200, 206):
             raise FileNotFoundError(
-                f"Unable to read resource {self._url}, or bytes are out of range; status code: {code}"
+                f"Unable to read resource {self._url}, or byte request {self._current_position}-{end_pos}"
+                f" is out of range; status code: {code}"
             )
 
         # verify this is not actually the whole file and the server did not lie

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -93,6 +93,9 @@ def _check_open(
             test_case.assertEqual(len(bytes_read), 0)
             bytes_read = read_buffer.read(size)
             test_case.assertEqual(len(bytes_read), 0)
+            read_buffer.seek(0)
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(bytes_read, content)
         # Write two copies of the content, overwriting the single copy there.
         with uri.open("w" + mode_suffix, **kwargs) as write_buffer:
             write_buffer.write(double_content)

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -84,6 +84,15 @@ def _check_open(
         # Read the file we created and check the contents.
         with uri.open("r" + mode_suffix, **kwargs) as read_buffer:
             test_case.assertEqual(read_buffer.read(), content)
+        # Check that we can read bytes in a loop and get EOF
+        with uri.open("r" + mode_suffix, **kwargs) as read_buffer:
+            size = len(bytes_content) * 3
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(bytes_read, content)
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(len(bytes_read), 0)
+            bytes_read = read_buffer.read(size)
+            test_case.assertEqual(len(bytes_read), 0)
         # Write two copies of the content, overwriting the single copy there.
         with uri.open("w" + mode_suffix, **kwargs) as write_buffer:
             write_buffer.write(double_content)


### PR DESCRIPTION
This is an alternative implementation of #49:

- It uses the Content-Range header to find the end (which works around the wsgidav bug (mar10/wsgidav#281).
- It falls back to comparing the size read to the requested size to indicate EOF.
- It disables Accept-Encoding when using byte ranges (since otherwise the byte ranges are for the compressed file).

The first change in particular allows the repeated use of read() to not need additional calls to the server off the end of the byte range.

I will integrate this back into #49 once reviewed.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
