### PR TITLE
DM-38492: Move ResourcePathExpression definition to end of file

### DIFF
--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -63,11 +63,6 @@ ESCAPED_HASH = urllib.parse.quote("#")
 MAX_WORKERS = 10
 
 
-ResourcePathExpression = Union[str, urllib.parse.ParseResult, "ResourcePath", Path]
-"""Type-annotation alias for objects that can be coerced to ResourcePath.
-"""
-
-
 class ResourcePath:
     """Convenience wrapper around URI parsers.
 
@@ -1404,3 +1399,8 @@ class ResourcePath:
             out_bytes = str_buffer.getvalue().encode(encoding)
         if "r" not in mode or "+" in mode:
             self.write(out_bytes, overwrite=("x" not in mode))
+
+
+ResourcePathExpression = Union[str, urllib.parse.ParseResult, ResourcePath, Path]
+"""Type-annotation alias for objects that can be coerced to ResourcePath.
+"""

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -13,11 +13,26 @@ import os
 import pathlib
 import unittest
 import unittest.mock
+import urllib.parse
 
-from lsst.resources import ResourcePath
+from lsst.resources import ResourcePath, ResourcePathExpression
 from lsst.resources.tests import GenericReadWriteTestCase, GenericTestCase
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class SimpleTestCase(unittest.TestCase):
+    def test_instance(self):
+        for example in (
+            "xxx",
+            ResourcePath("xxx"),
+            pathlib.Path("xxx"),
+            urllib.parse.urlparse("file:///xxx"),
+        ):
+            self.assertIsInstance(example, ResourcePathExpression)
+
+        for example in ({1, 2, 3}, 42, self):
+            self.assertNotIsInstance(example, ResourcePathExpression)
 
 
 class FileTestCase(GenericTestCase, unittest.TestCase):


### PR DESCRIPTION
This allows it to be a real definition rather than relying on a string to specify the ResourcePath entry. Doing it this away allows users to use ResourcePathExpression in an isinstance call.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
