### PR TITLE
DM-40573: Ensure checks of non-webDAV endpoints return False instead of raising

### DIFF
--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -318,10 +318,7 @@ def _is_webdav_endpoint(path: ResourcePath | str) -> bool:
                 ),
             )
             if resp.status_code not in (requests.codes.ok, requests.codes.created):
-                raise ValueError(
-                    f"Unexpected response to OPTIONS request for {path}, status: {resp.status_code} "
-                    f"{resp.reason}"
-                )
+                return False
 
             # Check that "1" is part of the value of the "DAV" header. We don't
             # use locks, so a server complying to class 1 is enough for our

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -693,6 +693,10 @@ class WebdavUtilsTestCase(unittest.TestCase):
         responses.add(responses.OPTIONS, plainHttpEndpoint, status=200)
         self.assertFalse(_is_webdav_endpoint(plainHttpEndpoint))
 
+        notWebdavEndpoint = "http://www.notwebdav.org"
+        responses.add(responses.OPTIONS, notWebdavEndpoint, status=403)
+        self.assertFalse(_is_webdav_endpoint(notWebdavEndpoint))
+
     def test_is_protected(self):
         self.assertFalse(_is_protected("/this-file-does-not-exist"))
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
