### PR TITLE
Fix pinning for v25 utils dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,8 +58,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -y -q \
-            "flake8<5" \
-            pytest pytest-flake8 pytest-xdist pytest-openfiles pytest-cov
+            pytest pytest-xdist pytest-openfiles pytest-cov
 
       - name: List installed packages
         shell: bash -l {0}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,11 +38,6 @@ jobs:
         run: |
           conda install -y -q cryptography
 
-      - name: Install WebDAV packages for testing
-        shell: bash -l {0}
-        run: |
-          pip install cheroot wsgidav
-
       - name: Install google cloud storage for testing
         shell: bash -l {0}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ s3 = [
 ]
 https = [
     "requests >= 2.26.0",
-    "urllib3 >= 1.25.10",
+    "urllib3 >= 1.25.10,<2.0.0",
     "responses >= 0.12.0",
 ]
 gs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 keywords = ["lsst"]
 dependencies = [
-    "lsst-utils",
+    "lsst-utils >=25.0,<25.100",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ gs = [
 ]
 test = [
     "pytest >= 3.2",
-    "flake8 >= 3.7.5",
-    "pytest-flake8 >= 1.0.4",
     "pytest-openfiles >= 0.5.0",
 ]
 
@@ -113,8 +111,7 @@ line_length = 110
 write_to = "python/lsst/resources/version.py"
 
 [tool.pytest.ini_options]
-addopts = "--flake8"
-flake8-ignore = ["N802", "N803", "N806", "N812", "N815", "N816", "W503", "E203"]
+addopts = "--import-mode=importlib"  # Recommended as best practice
 
 [tool.pydocstyle]
 convention = "numpy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/lsst/utils@main#egg=lsst-utils
+git+https://github.com/lsst/utils@v25.0.x#egg=lsst-utils
 # optional
 backoff >= 1.10
 boto3 >= 1.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ boto3 >= 1.13
 botocore >= 1.15
 moto >= 1.3
 responses >= 0.12.0
-urllib3 >= 1.25.10
+urllib3 >= 1.25.10, <2.0
 requests >= 2.26.0


### PR DESCRIPTION
Without this the package tries to download the newest release.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
