### PR TITLE
DM-42190: Fix mypy no-implicit-reexport compatibility

### DIFF
--- a/python/lsst/resources/__init__.py
+++ b/python/lsst/resources/__init__.py
@@ -12,6 +12,13 @@
 
 """ResourcePath is a package for abstracting access to local or remote files."""
 
+__all__ = (
+    "ResourceHandleProtocol",
+    "ResourcePath",
+    "ResourcePathExpression",
+)
+
+
 from ._resourceHandles import ResourceHandleProtocol
 
 # Should only expose ResourcePath and its input type alias


### PR DESCRIPTION
SQRE repositories have their mypy configured with `no-implicit-reexport` enabled, which prevents you from using symbols imported by name into a module from another module unless they are listed in `__all__`.

Before this change, mypy would fail with an `attr-defined` error if you tried to `from lsst.resources import ResourcePath`.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
