### PR TITLE
DM-41547: Remove test dependencies from s3 and https deps

### DIFF
--- a/doc/changes/DM-41547.bugfix.rst
+++ b/doc/changes/DM-41547.bugfix.rst
@@ -1,0 +1,1 @@
+Installing optional dependencies for ``s3`` and ``https`` will no longer pull in libraries only required for running unit tests (``moto`` and ``responses``).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,22 +33,22 @@ requires-python = ">=3.11.0"
 [project.optional-dependencies]
 s3 = [
     "boto3 >= 1.13",
-    "moto >= 1.3",
     "backoff >= 1.10",
 ]
 https = [
     "astropy >= 4.0",
     "requests >= 2.26.0",
     "urllib3 >= 1.25.10",
-    "responses >= 0.12.0",
     "defusedxml",
 ]
 gs = [
     "google-cloud-storage",
 ]
 test = [
+    "moto >= 1.3",
     "pytest >= 3.2",
     "pytest-openfiles >= 0.5.0",
+    "responses >= 0.12.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The s3 and https optional dependency groups included dependencies that are only needed for running tests.  This was causing downstream users to pull in unnecessary dependencies.  These deps have now been moved to the "test" group.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
