### PR TITLE
DM-43739: Fix memory leak in HTTPResourcePath

### DIFF
--- a/doc/changes/DM-43739.bugfix.md
+++ b/doc/changes/DM-43739.bugfix.md
@@ -1,0 +1,1 @@
+`ResourePath.root_uri()` now strips query parameters and fragments from the URL.  This fixes a memory leak where `HttpResourcePath` would create and cache a new HTTP session for each different set of query parameters.

--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -417,7 +417,7 @@ class ResourcePath:  # numpydoc ignore=PR02
         uri : `ResourcePath`
             Root URI.
         """
-        return self.replace(path="", forceDirectory=True)
+        return self.replace(path="", query="", fragment="", params="", forceDirectory=True)
 
     def split(self) -> tuple[ResourcePath, str]:
         """Split URI into head and tail.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -59,6 +59,29 @@ class GenericHttpTestCase(GenericTestCase, unittest.TestCase):
     scheme = "http"
     netloc = "server.example"
 
+    def test_root_uri(self):
+        self.assertEqual(ResourcePath("http://server.com").root_uri(), ResourcePath("http://server.com/"))
+        self.assertEqual(
+            ResourcePath("http://user:password@server.com:3000/").root_uri(),
+            ResourcePath("http://user:password@server.com:3000/"),
+        )
+        self.assertEqual(
+            ResourcePath("http://user:password@server.com:3000/some/path").root_uri(),
+            ResourcePath("http://user:password@server.com:3000/"),
+        )
+        self.assertEqual(
+            ResourcePath("http://user:password@server.com:3000/some/path#fragment").root_uri(),
+            ResourcePath("http://user:password@server.com:3000/"),
+        )
+        self.assertEqual(
+            ResourcePath("http://user:password@server.com:3000/some/path?param=value").root_uri(),
+            ResourcePath("http://user:password@server.com:3000/"),
+        )
+        self.assertEqual(
+            ResourcePath("http://user:password@server.com:3000/some/path;parameters").root_uri(),
+            ResourcePath("http://user:password@server.com:3000/"),
+        )
+
 
 class HttpReadWriteWebdavTestCase(GenericReadWriteTestCase, unittest.TestCase):
     """Test with a real webDAV server, as opposed to mocking responses."""


### PR DESCRIPTION
Fixed an issue where query parameters or fragments in an HTTP URL would cause it to be considered as having a different root URI.  This caused a new HTTP session to be created and cached each time an HTTP URL with a different query parameter was accessed.

This resulted in a memory leak in datalinker when it was using HTTPResourcePath to access S3 presigned URLs, which always have unique query parameters.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
