### PR TITLE
DM-44398: Use temporary_uri inside transfer_from

### DIFF
--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -953,7 +953,10 @@ class ResourcePath:  # numpydoc ignore=PR02
     @classmethod
     @contextlib.contextmanager
     def temporary_uri(
-        cls, prefix: ResourcePath | None = None, suffix: str | None = None
+        cls,
+        prefix: ResourcePath | None = None,
+        suffix: str | None = None,
+        delete: bool = True,
     ) -> Iterator[ResourcePath]:
         """Create a temporary file-like URI.
 
@@ -966,6 +969,11 @@ class ResourcePath:  # numpydoc ignore=PR02
         suffix : `str`, optional
             A file suffix to be used. The ``.`` should be included in this
             suffix.
+        delete : `bool`, optional
+            By default the resource will be deleted when the context manager
+            is exited. Setting this flag to `False` will leave the resource
+            alone. `False` will also retain any directories that may have
+            been created.
 
         Yields
         ------
@@ -1002,13 +1010,14 @@ class ResourcePath:  # numpydoc ignore=PR02
         try:
             yield temporary_uri
         finally:
-            if use_tempdir:
-                shutil.rmtree(prefix.ospath, ignore_errors=True)
-            else:
-                with contextlib.suppress(FileNotFoundError):
-                    # It's okay if this does not work because the user removed
-                    # the file.
-                    temporary_uri.remove()
+            if delete:
+                if use_tempdir:
+                    shutil.rmtree(prefix.ospath, ignore_errors=True)
+                else:
+                    with contextlib.suppress(FileNotFoundError):
+                        # It's okay if this does not work because the user
+                        # removed the file.
+                        temporary_uri.remove()
 
     def read(self, size: int = -1) -> bytes:
         """Open the resource and return the contents in bytes.

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -148,12 +148,12 @@ class FileReadWriteTestCase(GenericReadWriteTestCase, unittest.TestCase):
         with ResourcePath.temporary_uri(suffix=".yaml", delete=False) as tmp:
             tmp.write(b"1234")
             self.assertTrue(tmp.exists(), f"uri: {tmp}")
-        exists = tmp.exists()
-        try:
-            tmp.remove()
-        except Exception:
-            pass
-        self.assertTrue(exists, f"uri: {tmp} should still exist")
+        # If the file doesn't exist there is nothing to clean up so a failure
+        # here is not a problem.
+        self.assertTrue(tmp.exists(), f"uri: {tmp} should still exist")
+
+        # If removal does not work it's worth reporting that as an error.
+        tmp.remove()
 
     def test_transfers_from_local(self):
         """Extra tests for local transfers."""

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -145,6 +145,16 @@ class FileReadWriteTestCase(GenericReadWriteTestCase, unittest.TestCase):
             self.assertTrue(tmp.exists())
         self.assertFalse(tmp.exists(), f"uri: {tmp}")
 
+        with ResourcePath.temporary_uri(suffix=".yaml", delete=False) as tmp:
+            tmp.write(b"1234")
+            self.assertTrue(tmp.exists(), f"uri: {tmp}")
+        exists = tmp.exists()
+        try:
+            tmp.remove()
+        except Exception:
+            pass
+        self.assertTrue(exists, f"uri: {tmp} should still exist")
+
     def test_transfers_from_local(self):
         """Extra tests for local transfers."""
         target = self.tmpdir.join("a/target.txt")


### PR DESCRIPTION
This allows umask to be used when creating the files.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
