### PR TITLE
DM-44762: Fixes to open() interface

### DIFF
--- a/doc/changes/DM-44762.feature.rst
+++ b/doc/changes/DM-44762.feature.rst
@@ -1,0 +1,2 @@
+Added a ``.name`` (string) property to the handles returned by ``ResourcePath.open()``.
+Previously only the handle for local files had this property.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,13 @@ exclude_lines = [
 ]
 
 [tool.ruff]
+line-length = 110
+target-version = "py311"
 exclude = [
     "__init__.py",
 ]
+
+[tool.ruff.lint]
 ignore = [
     "N802",
     "N803",
@@ -157,7 +161,6 @@ ignore = [
     "D205",
     "D400",
 ]
-line-length = 110
 select = [
     "E",  # pycodestyle
     "F",  # pyflakes
@@ -167,15 +170,14 @@ select = [
     "UP",  # pyupgrade
     "C4",
 ]
-target-version = "py310"
 extend-select = [
     "RUF100", # Warn about unused noqa
 ]
 
-[tool.ruff.pycodestyle]
+[tool.ruff.lint.pycodestyle]
 max-doc-length = 79
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.numpydoc_validation]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ version = { attr = "lsst_versions.get_lsst_version" }
 
 [tool.black]
 line-length = 110
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"

--- a/python/lsst/resources/_resourcePath.py
+++ b/python/lsst/resources/_resourcePath.py
@@ -1470,6 +1470,7 @@ class ResourcePath:  # numpydoc ignore=PR02
         in_bytes = self.read() if "r" in mode or "a" in mode else b""
         if "b" in mode:
             bytes_buffer = io.BytesIO(in_bytes)
+            bytes_buffer.name = str(self)
             if "a" in mode:
                 bytes_buffer.seek(0, io.SEEK_END)
             yield bytes_buffer
@@ -1478,6 +1479,7 @@ class ResourcePath:  # numpydoc ignore=PR02
             if encoding is None:
                 encoding = locale.getpreferredencoding(False)
             str_buffer = io.StringIO(in_bytes.decode(encoding))
+            str_buffer.name = str(self)
             if "a" in mode:
                 str_buffer.seek(0, io.SEEK_END)
             yield str_buffer

--- a/python/lsst/resources/file.py
+++ b/python/lsst/resources/file.py
@@ -479,7 +479,7 @@ class FileResourcePath(ResourcePath):
         *,
         encoding: str | None = None,
     ) -> Iterator[IO]:
-        with FileResourceHandle(mode=mode, log=log, filename=self.ospath, encoding=encoding) as buffer:
+        with FileResourceHandle(mode=mode, log=log, uri=self, encoding=encoding) as buffer:
             yield buffer  # type: ignore
 
 

--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -1565,9 +1565,7 @@ class HttpResourcePath(ResourcePath):
         accepts_range = resp.status_code == requests.codes.ok and resp.headers.get("Accept-Ranges") == "bytes"
         handle: ResourceHandleProtocol
         if mode in ("rb", "r") and accepts_range:
-            handle = HttpReadResourceHandle(
-                mode, log, url=self.geturl(), session=self.data_session, timeout=self._config.timeout
-            )
+            handle = HttpReadResourceHandle(mode, log, self, timeout=self._config.timeout)
             if mode == "r":
                 # cast because the protocol is compatible, but does not have
                 # BytesIO in the inheritance tree

--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -1333,7 +1333,10 @@ class HttpResourcePath(ResourcePath):
         )
 
     def _head(self) -> requests.Response:
-        """Send a HEAD webDAV request for this resource."""
+        """Send a HEAD request for this resource."""
+        if not self.is_webdav_endpoint:
+            # The remote is a plain HTTP server.
+            return self._head_non_webdav_url()
         return self._send_webdav_request("HEAD")
 
     def _mkcol(self) -> None:

--- a/python/lsst/resources/s3.py
+++ b/python/lsst/resources/s3.py
@@ -98,13 +98,15 @@ class ProgressPercentage:
             )
 
 
-def _translate_client_error(err: ClientError) -> None:
+def _translate_client_error(err: ClientError, uri: ResourcePath) -> None:
     """Translate a ClientError into a specialist error if relevant.
 
     Parameters
     ----------
     err : `ClientError`
         Exception to translate.
+    uri : `ResourcePath`
+        The URI of the resource that is resulting in the error.
 
     Raises
     ------
@@ -115,10 +117,10 @@ def _translate_client_error(err: ClientError) -> None:
         # ClientError includes the error code in the message
         # but no direct way to access it without looking inside the
         # response.
-        raise _TooManyRequestsError(str(err)) from err
+        raise _TooManyRequestsError(f"{err} when accessing {uri}") from err
     elif "(404)" in str(err):
         # Some systems can generate this rather than NoSuchKey.
-        raise FileNotFoundError("Resource not found: {self}")
+        raise FileNotFoundError(f"Resource not found (permission denied): {uri}")
 
 
 @cache
@@ -277,7 +279,7 @@ class S3ResourcePath(ResourcePath):
         except (self.client.exceptions.NoSuchKey, self.client.exceptions.NoSuchBucket) as err:
             raise FileNotFoundError(f"No such resource: {self}") from err
         except ClientError as err:
-            _translate_client_error(err)
+            _translate_client_error(err, self)
             raise
         with time_this(log, msg="Read from %s", args=(self,)):
             body = response["Body"].read()
@@ -327,7 +329,7 @@ class S3ResourcePath(ResourcePath):
         ) as err:
             raise FileNotFoundError(f"No such resource: {self}") from err
         except ClientError as err:
-            _translate_client_error(err)
+            _translate_client_error(err, self)
             raise
 
     def _as_local(self) -> tuple[str, bool]:
@@ -366,7 +368,7 @@ class S3ResourcePath(ResourcePath):
         except self.client.exceptions.NoSuchBucket as err:
             raise NotADirectoryError(f"Target does not exist: {err}") from err
         except ClientError as err:
-            _translate_client_error(err)
+            _translate_client_error(err, self)
             raise
 
     @backoff.on_exception(backoff.expo, all_retryable_errors, max_time=max_retry_time)
@@ -380,7 +382,7 @@ class S3ResourcePath(ResourcePath):
         except (self.client.exceptions.NoSuchKey, self.client.exceptions.NoSuchBucket) as err:
             raise FileNotFoundError("No such resource to transfer: {self}") from err
         except ClientError as err:
-            _translate_client_error(err)
+            _translate_client_error(err, self)
             raise
 
     def transfer_from(

--- a/python/lsst/resources/s3.py
+++ b/python/lsst/resources/s3.py
@@ -544,9 +544,7 @@ class S3ResourcePath(ResourcePath):
         *,
         encoding: str | None = None,
     ) -> Iterator[ResourceHandleProtocol]:
-        with S3ResourceHandle(
-            mode, log, self.client, self._bucket, self.relativeToPathRoot, uri=self
-        ) as handle:
+        with S3ResourceHandle(mode, log, self) as handle:
             if "b" in mode:
                 yield handle
             else:

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -85,6 +85,9 @@ def _check_open(
         # Read the file we created and check the contents.
         with uri.open("r" + mode_suffix, **kwargs) as read_buffer:
             test_case.assertEqual(read_buffer.read(), content)
+            # The names will not match if a local temporary is being written.
+            if not kwargs.get("prefer_file_temporary"):
+                test_case.assertIn(uri.basename(), read_buffer.name)
         # Check that we can read bytes in a loop and get EOF
         with uri.open("r" + mode_suffix, **kwargs) as read_buffer:
             # Seek off the end of the file and should read empty back.

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -168,6 +168,10 @@ class S3ReadWriteTestCaseBase(GenericReadWriteTestCase):
         self.assertTrue(get_path.exists())
         self.assertEqual(get_path.size(), len(test_data))
 
+        # Try again with open().
+        with get_path.open("rb") as fd:
+            self.assertEqual(fd.read(), test_data)
+
     def test_nonexistent_presigned_url(self):
         s3_path = self.root_uri.join("this-is-a-missing-file.txt")
         get_url = s3_path.generate_presigned_get_url(expiration_time_seconds=3600)


### PR DESCRIPTION
* Add a `.name` property to the `ResourceHandle` interface to match that returned by standard `open()`.
* Fix `.open()` for non-WebDAV servers.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
