### PR TITLE
DM-44840: Change default directory used for temp files

### DIFF
--- a/doc/changes/DM-44840.bugfix.md
+++ b/doc/changes/DM-44840.bugfix.md
@@ -1,0 +1,1 @@
+If there is no environment variable set explicitly declaring the directory to use for temporary files, `HttpResourcePath` now creates temporary files in the system default temporary directory instead of the current working directory.

--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -23,6 +23,7 @@ import os.path
 import random
 import re
 import stat
+import tempfile
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, BinaryIO, cast
 
@@ -364,8 +365,10 @@ def _get_temp_dir() -> tuple[str, int]:
         return _TMPDIR
 
     # Use the value of environment variables 'LSST_RESOURCES_TMPDIR' or
-    # 'TMPDIR', if defined. Otherwise use current working directory.
-    tmpdir = os.getcwd()
+    # 'TMPDIR', if defined. Otherwise use the system temporary directory,
+    # with a last-resort fallback to the current working directory if nothing
+    # else is available.
+    tmpdir = tempfile.gettempdir()
     for dir in (os.getenv(v) for v in ("LSST_RESOURCES_TMPDIR", "TMPDIR")):
         if dir and os.path.isdir(dir):
             tmpdir = dir


### PR DESCRIPTION
Previously, if there was not an environment variable set explicitly defining the location of the temporary directory, HttpResourcePath would use the current working directory during downloads.  This is a bad default for a few reasons:
1. It has frequently caused issues when using the library on systems with read-only directories (like containers and notebooks.)
2. On many systems where the library is used, the current working directory can be a slow network filesystem.
3.  It's surprising in general -- all operating systems have a well-defined default temporary directory.

Instead we now use the same directory as Python's default temporary directory, which chooses something appropriate based on the environment and operating system.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
