### PR TITLE
DM-46025: Force a default AWS region for S3 tests

### DIFF
--- a/python/lsst/resources/s3utils.py
+++ b/python/lsst/resources/s3utils.py
@@ -161,6 +161,7 @@ def clean_test_environment_for_s3() -> Iterator[None]:
         {
             "AWS_ACCESS_KEY_ID": "test-access-key",
             "AWS_SECRET_ACCESS_KEY": "test-secret-access-key",
+            "AWS_DEFAULT_REGION": "us-east-1",
         },
     ) as patched_environ:
         for var in (


### PR DESCRIPTION
This prevents problems when there is a local override in ~/.aws/config.

Note that we use "us-east-1" for all tests. "us-west-1" does not work. In theory MOTO_ALLOW_NONEXISTENT_REGION could be set to allow an arbitrary fake region to be used but that does not seem to work with our tests at present.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
