### PR TITLE
DM-46139: Add option to disable multithreaded S3 uploads

### DIFF
--- a/doc/changes/DM-46139.feature.md
+++ b/doc/changes/DM-46139.feature.md
@@ -1,0 +1,1 @@
+Allow ``LSST_S3_USE_THREADS`` environment variable to control multithreading for S3 uploads, in addition to downloads.

--- a/python/lsst/resources/s3.py
+++ b/python/lsst/resources/s3.py
@@ -375,7 +375,11 @@ class S3ResourcePath(ResourcePath):
         """
         try:
             self.client.upload_file(
-                local_file.ospath, self._bucket, self.relativeToPathRoot, Callback=progress
+                local_file.ospath,
+                self._bucket,
+                self.relativeToPathRoot,
+                Callback=progress,
+                Config=self._transfer_config,
             )
         except self.client.exceptions.NoSuchBucket as err:
             raise NotADirectoryError(f"Target does not exist: {err}") from err


### PR DESCRIPTION
We already have an option to disable multithreading in downloads via `LSST_S3_USE_THREADS` environment variable. This option may be useful for uploads too, updating the code to use it for uploads.

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
