### PR TITLE
DM-46701: Implement generate_presigned_get_url for plain HTTP

### DIFF
--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -1261,7 +1261,9 @@ class HttpResourcePath(ResourcePath):
             HTTP URL signed for GET.
         """
         if not self.is_webdav_endpoint:
-            return super().generate_presigned_get_url(expiration_time_seconds=expiration_time_seconds)
+            # This is already an HTTP URL readable without any authentication
+            # credentials, so return it as-is.
+            return str(self)
 
         return self._sign_with_macaroon(ActivityCaveat.DOWNLOAD, expiration_time_seconds)
 

--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -1869,7 +1869,7 @@ class HttpResourcePath(ResourcePath):
             if mode == "r":
                 # cast because the protocol is compatible, but does not have
                 # BytesIO in the inheritance tree
-                yield io.TextIOWrapper(cast(io.BytesIO, handle), encoding=encoding)
+                yield io.TextIOWrapper(cast(Any, handle), encoding=encoding)
             else:
                 yield handle
         else:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -461,6 +461,25 @@ class HttpReadWriteWebdavTestCase(GenericReadWriteTestCase, unittest.TestCase):
         self.assertFalse(ResourcePath(notWebdavEndpoint).is_webdav_endpoint)
 
     @responses.activate
+    def test_plain_http_url_signing(self):
+        # As in test_is_webdav_endpoint above, configure a URL to appear as a
+        # non-webdav HTTP server.
+        plainHttpEndpoint = "http://nonwebdav.test"
+        responses.add(responses.OPTIONS, plainHttpEndpoint, status=200)
+
+        # Plain HTTP URLs are already readable without authentication, so
+        # generating a pre-signed URL is a no-op.
+        path = ResourcePath("http://nonwebdav.test/file")
+        self.assertEqual(
+            path.generate_presigned_get_url(expiration_time_seconds=300), "http://nonwebdav.test/file"
+        )
+
+        # Writing to an arbitrary plain HTTP URL is unlikely to work, so we
+        # don't generate put URLs.
+        with self.assertRaises(NotImplementedError):
+            path.generate_presigned_put_url(expiration_time_seconds=300)
+
+    @responses.activate
     def test_server_identity(self):
         server = "MyServer/v1.2.3"
         endpointWithServer = "http://www.lsstwithserverheader.org"


### PR DESCRIPTION
Provide a no-op implementation of generate_presigned_get_url() for plain HTTP URLs that returns the URL unchanged.

This will allow Butler server to serve read-only data from plain HTTP roots.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
