### PR TITLE
DM-47357: Explicitly configure timeouts for fsspec

### DIFF
--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -1343,7 +1343,9 @@ class HttpResourcePath(ResourcePath):
                     limit_per_host=1,
                     # Time to keep open connections alive (unit is likely
                     # seconds, even if not documented). The default is 15.0
-                    keepalive_timeout=15.0,
+                    # keepalive_timeout=15.0,
+                    # Close network connection after usage
+                    force_close=True,
                 )
 
             connect_timeout, read_timeout = self._config.timeout

--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -1354,7 +1354,7 @@ class HttpResourcePath(ResourcePath):
         # This needs more investigation to discard the possibility that async
         # I/O, used by fsspec.HTTPFileSystem, is related to this behavior.
         if not self._config.fsspec_is_enabled:
-            raise ImportError("fsspec is disabled for HttpResourcePath objects")
+            raise ImportError("fsspec is disabled for HttpResourcePath objects with webDAV back end")
 
         async def get_client_session(**kwargs: Any) -> ClientSession:
             """Return a aiohttp.ClientSession configured to use an

--- a/python/lsst/resources/http.py
+++ b/python/lsst/resources/http.py
@@ -761,7 +761,7 @@ class HttpResourcePath(ResourcePath):
     SUPPORTED_URL_SIGNERS = ("dcache", "xrootd")
 
     # Configuration items for this class instances.
-    _config = HttpResourcePathConfig()
+    _config: HttpResourcePathConfig = HttpResourcePathConfig()
 
     # The session for metadata requests is used for interacting with
     # the front end servers for requests such as PROPFIND, HEAD, etc. Those

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -920,6 +920,10 @@ class GenericReadWriteTestCase(_GenericTestCase):
             fs, path = uri.to_fsspec()
         except NotImplementedError as e:
             raise unittest.SkipTest(str(e)) from e
+        except ImportError as e:
+            # HttpResourcePath.to_fsspec() raises if support
+            # of fsspec for webDAV back ends is disabled.
+            raise unittest.SkipTest(str(e)) from e
         with fs.open(path, "r") as fd:
             as_read = fd.read()
         self.assertEqual(as_read, content)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -39,7 +39,13 @@ from lsst.resources._resourceHandles._httpResourceHandle import (
     HttpReadResourceHandle,
     parse_content_range_header,
 )
-from lsst.resources.http import BearerTokenAuth, HttpResourcePathConfig, SessionStore, _is_protected
+from lsst.resources.http import (
+    BearerTokenAuth,
+    HttpResourcePath,
+    HttpResourcePathConfig,
+    SessionStore,
+    _is_protected,
+)
 from lsst.resources.tests import GenericReadWriteTestCase, GenericTestCase
 from lsst.resources.utils import makeTestTempDir, removeTestTempDir
 
@@ -411,7 +417,7 @@ class HttpReadWriteWebdavTestCase(GenericReadWriteTestCase, unittest.TestCase):
         os.remove(local_file)
 
     def test_dav_to_fsspec(self):
-        # Upload a randomly-generated file via write() with overwrite
+        # Upload a randomly-generated file via write() with overwrite.
         local_file, file_size = self._generate_file()
         with open(local_file, "rb") as f:
             data = f.read()
@@ -420,31 +426,51 @@ class HttpReadWriteWebdavTestCase(GenericReadWriteTestCase, unittest.TestCase):
         self.assertIsNone(remote_file.write(data, overwrite=True))
         self.assertTrue(remote_file.exists())
         self.assertEqual(remote_file.size(), file_size)
+        remote_file_url = remote_file.geturl()
 
-        try:
-            # Ensure that the contents of the remote file we just uploaded is
-            # identical to the contents of that file when retrieved via
-            # fsspec.open().
-            fsys, url = remote_file.to_fsspec()
-            with fsys.open(url) as f:
-                self.assertEqual(data, f.read())
+        # Ensure to_fsspec() raises if that feature is not specifically
+        # enabled in the environment.
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ImportError):
+                # Force reinitialization of the config from the environment
+                HttpResourcePath._reload_config()
+                ResourcePath(remote_file_url).to_fsspec()
 
-            # Ensure the contents is identical to the result of fsspec.cat()
-            self.assertEqual(data, fsys.cat(url))
-        except NotImplementedError as e:
-            # to_fsspec() must succeed if remote server knows how to sign URLs
-            if remote_file.server_signs_urls:
-                raise e
-        finally:
-            os.remove(local_file)
+        # Ensure to_fsspec() works if that feature is enabled in the
+        # environment.
+        with unittest.mock.patch.dict(os.environ, {"LSST_HTTP_ENABLE_FSSPEC": "true"}, clear=True):
+            try:
+                # Force reinitialization of the config from the environment.
+                HttpResourcePath._reload_config()
+                rpath = ResourcePath(remote_file_url)
 
-        # Ensure that attempting to modify a remote via via fsspec fails.
-        # fsspect.rm() raises NotImplementedError if it cannot remove the
-        # remote file.
-        if remote_file.server_signs_urls:
-            fsys, url = remote_file.to_fsspec()
-            with self.assertRaises(NotImplementedError):
-                fsys.rm(url)
+                # Ensure that the contents of the remote file we just
+                # uploaded is identical to the contents of that file when
+                # retrieved via fsspec.open().
+                fsys, url = rpath.to_fsspec()
+                with fsys.open(url) as f:
+                    self.assertEqual(data, f.read())
+
+                # Ensure the contents is identical to the result of
+                # fsspec.cat()
+                self.assertEqual(data, fsys.cat(url))
+
+                # Ensure that attempting to modify a remote via via fsspec
+                # fails, since the returned URL is signed for download only.
+                # fsspec.rm() raises NotImplementedError if it cannot remove
+                # the remote file.
+                if rpath.server_signs_urls:
+                    with self.assertRaises(NotImplementedError):
+                        fsys, url = rpath.to_fsspec()
+                        fsys.rm(url)
+            except NotImplementedError as e:
+                # to_fsspec() must succeed if remote server knows how to
+                # sign URLs
+                if rpath.server_signs_urls:
+                    raise e
+
+        # Clean up
+        os.remove(local_file)
 
     @responses.activate
     def test_is_webdav_endpoint(self):
@@ -619,7 +645,7 @@ class HttpResourcePathConfigTestCase(unittest.TestCase):
 
     def test_send_expect_header(self):
         # Ensure environment variable LSST_HTTP_PUT_SEND_EXPECT_HEADER is
-        # inspected to initialize the HttpResourcePathConfig config class.
+        # inspected to initialize the HttpResourcePathConfig class.
         with unittest.mock.patch.dict(os.environ, {}, clear=True):
             config = HttpResourcePathConfig()
             self.assertFalse(config.send_expect_on_put)
@@ -627,6 +653,17 @@ class HttpResourcePathConfigTestCase(unittest.TestCase):
         with unittest.mock.patch.dict(os.environ, {"LSST_HTTP_PUT_SEND_EXPECT_HEADER": "true"}, clear=True):
             config = HttpResourcePathConfig()
             self.assertTrue(config.send_expect_on_put)
+
+    def test_enable_fsspec(self):
+        # Ensure environment variable LSST_HTTP_ENABLE_FSSPEC is
+        # inspected to initialize the HttpResourcePathConfig class.
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            config = HttpResourcePathConfig()
+            self.assertFalse(config.fsspec_is_enabled)
+
+        with unittest.mock.patch.dict(os.environ, {"LSST_HTTP_ENABLE_FSSPEC": "any value"}, clear=True):
+            config = HttpResourcePathConfig()
+            self.assertTrue(config.fsspec_is_enabled)
 
     def test_collect_memory_usage(self):
         # Ensure environment variable LSST_HTTP_COLLECT_MEMORY_USAGE is

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -469,7 +469,9 @@ class HttpReadWriteWebdavTestCase(GenericReadWriteTestCase, unittest.TestCase):
                 if rpath.server_signs_urls:
                     raise e
 
-        # Clean up
+        # Force reinitialization of the config from the environment and
+        # clean up local file.
+        HttpResourcePath._reload_config()
         os.remove(local_file)
 
     @responses.activate


### PR DESCRIPTION
The default timeout and number of TCP connections kept alive by fsspec' HTTPFileSystem are not suitable for production conditions so we set them to more reasonable values based on observed behavior.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
