### PR TITLE
DM-47673: v28 release notes (cherry-picked)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -22,7 +22,7 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.8
+    rev: v0.7.4
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc

--- a/doc/changes/DM-44486.bugfix.rst
+++ b/doc/changes/DM-44486.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed the usage of ``SEEK_END`` in S3 and HTTP resource path handles.

--- a/doc/changes/DM-44547.feature.rst
+++ b/doc/changes/DM-44547.feature.rst
@@ -1,1 +1,0 @@
-Added a new method ``ResourcePath.to_fsspec()`` to return ``fsspec`` file system objects suitable for use in packages such as Astropy and Pyarrow.

--- a/doc/changes/DM-44762.feature.rst
+++ b/doc/changes/DM-44762.feature.rst
@@ -1,2 +1,0 @@
-Added a ``.name`` (string) property to the handles returned by ``ResourcePath.open()``.
-Previously only the handle for local files had this property.

--- a/doc/changes/DM-44840.bugfix.md
+++ b/doc/changes/DM-44840.bugfix.md
@@ -1,1 +1,0 @@
-If there is no environment variable set explicitly declaring the directory to use for temporary files, `HttpResourcePath` now creates temporary files in the system default temporary directory instead of the current working directory.

--- a/doc/changes/DM-45732.misc.rst
+++ b/doc/changes/DM-45732.misc.rst
@@ -1,1 +1,0 @@
-``S3ResourceHandle`` now correctly converts ``NoSuchKey`` exception to ``FileNotFoundError`` when a read is attempted.

--- a/doc/changes/DM-46139.feature.md
+++ b/doc/changes/DM-46139.feature.md
@@ -1,1 +1,0 @@
-Allow ``LSST_S3_USE_THREADS`` environment variable to control multithreading for S3 uploads, in addition to downloads.

--- a/doc/lsst.resources/CHANGES.rst
+++ b/doc/lsst.resources/CHANGES.rst
@@ -1,3 +1,28 @@
+Resources v28.0.0 2024-11-20
+============================
+
+New Features
+------------
+
+- Added a new method ``ResourcePath.to_fsspec()`` to return ``fsspec`` file system objects suitable for use in packages such as Astropy and Pyarrow. (`DM-44547 <https://rubinobs.atlassian.net/browse/DM-44547>`_)
+- Added a ``.name`` (string) property to the handles returned by ``ResourcePath.open()``.
+  Previously only the handle for local files had this property. (`DM-44762 <https://rubinobs.atlassian.net/browse/DM-44762>`_)
+- Added support for the ``LSST_S3_USE_THREADS`` environment variable to control multithreading for S3 uploads, in addition to downloads. (`DM-46139 <https://rubinobs.atlassian.net/browse/DM-46139>`_)
+
+
+Bug Fixes
+---------
+
+- Fixed the usage of ``SEEK_END`` in S3 and HTTP resource path handles. (`DM-44486 <https://rubinobs.atlassian.net/browse/DM-44486>`_)
+- If there is no environment variable set explicitly declaring the directory to use for temporary files, ``HttpResourcePath`` now creates temporary files in the system default temporary directory instead of the current working directory. (`DM-44840 <https://rubinobs.atlassian.net/browse/DM-44840>`_)
+
+
+Miscellaneous Changes of Minor Interest
+---------------------------------------
+
+- ``S3ResourceHandle`` now correctly converts ``NoSuchKey`` exception to ``FileNotFoundError`` when a read is attempted. (`DM-45732 <https://rubinobs.atlassian.net/browse/DM-45732>`_)
+
+
 Resources 27.0.0 2024-05-28
 ===========================
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
