### PR TITLE
DM-51087: Only flush if the buffer has grown big enough to flush

### DIFF
--- a/doc/changes/DM-51087.misc.rst
+++ b/doc/changes/DM-51087.misc.rst
@@ -1,0 +1,2 @@
+* Fixed problem with multiple ``flush()`` calls with S3 resource handle for small chunks.
+* Fixed bug in File resource handle where ``flush()`` was mistakenly calling ``close()``.

--- a/python/lsst/resources/_resourceHandles/_fileResourceHandle.py
+++ b/python/lsst/resources/_resourceHandles/_fileResourceHandle.py
@@ -79,7 +79,7 @@ class FileResourceHandle(BaseResourceHandle[U]):
         return self._fileHandle.fileno()
 
     def flush(self) -> None:
-        self._fileHandle.close()
+        self._fileHandle.flush()
 
     @property
     def isatty(self) -> bool:

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -143,6 +143,16 @@ def _check_open(
             content_read = read_buffer.read()
             test_case.assertEqual(len(content_read), 0, f"Read: {content_read!r}, expected empty.")
 
+        # Write multiple chunks with flushing to ensure that any handles that
+        # cache without flushing work properly.
+        n = 3
+        with uri.open("w" + mode_suffix, **kwargs) as write_buffer:
+            for _ in range(n):
+                write_buffer.write(content)
+                write_buffer.flush()
+        with uri.open("r" + mode_suffix, **kwargs) as read_buffer:
+            test_case.assertEqual(read_buffer.read(), content * n)
+
         # Write two copies of the content, overwriting the single copy there.
         with uri.open("w" + mode_suffix, **kwargs) as write_buffer:
             write_buffer.write(double_content)

--- a/python/lsst/resources/tests.py
+++ b/python/lsst/resources/tests.py
@@ -61,18 +61,18 @@ def _check_open(
     """
     text_content = "abcdefghijklmnopqrstuvwxyz🙂"
     bytes_content = uuid.uuid4().bytes
-    content_by_mode_suffix = {
+    content_by_mode_suffix: dict[str, str | bytes] = {
         "": text_content,
         "t": text_content,
         "b": bytes_content,
     }
-    empty_content_by_mode_suffix = {
+    empty_content_by_mode_suffix: dict[str, str | bytes] = {
         "": "",
         "t": "",
         "b": b"",
     }
     # To appease mypy
-    double_content_by_mode_suffix = {
+    double_content_by_mode_suffix: dict[str, str | bytes] = {
         "": text_content + text_content,
         "t": text_content + text_content,
         "b": bytes_content + bytes_content,


### PR DESCRIPTION
Previously we were skipping the flush only the first time through (trying not to warn the user).

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
