### PR TITLE
DM-51384: Fix AccessDenied when copying between S3 with different profiles

### DIFF
--- a/doc/changes/DM-51384.bugfix.md
+++ b/doc/changes/DM-51384.bugfix.md
@@ -1,0 +1,1 @@
+Fix an issue where S3ResourcePath.transfer_from(S3ResourcePath) would fail when the source and destination were using different S3 endpoints or sets of credentials.

--- a/python/lsst/resources/s3.py
+++ b/python/lsst/resources/s3.py
@@ -542,7 +542,7 @@ class S3ResourcePath(ResourcePath):
         try:
             self.client.copy_object(CopySource=copy_source, Bucket=self._bucket, Key=self.relativeToPathRoot)
         except (self.client.exceptions.NoSuchKey, self.client.exceptions.NoSuchBucket) as err:
-            raise FileNotFoundError(f"No such resource to transfer: {self}") from err
+            raise FileNotFoundError(f"No such resource to transfer: {src} -> {self}") from err
         except ClientError as err:
             translate_client_error(err, self)
             raise

--- a/python/lsst/resources/s3.py
+++ b/python/lsst/resources/s3.py
@@ -609,10 +609,10 @@ class S3ResourcePath(ResourcePath):
         timer_msg = "Transfer from %s to %s"
         timer_args = (src, self)
 
-        if isinstance(src, type(self)):
-            # Looks like an S3 remote uri so we can use direct copy
-            # note that boto3.resource.meta.copy is cleverer than the low
-            # level copy_object
+        if isinstance(src, type(self)) and self.client == src.client:
+            # Looks like an S3 remote uri so we can use direct copy.
+            # This only works if the source and destination are using the same
+            # S3 endpoint and profile.
             with time_this(log, msg=timer_msg, args=timer_args):
                 self._copy_from(src)
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -351,6 +351,17 @@ class S3WithProfileReadWriteTestCase(S3ReadWriteTestCaseBase, unittest.TestCase)
         self.assertEqual(path2._bucket, "ceph:bucket2")
         self.assertIsNone(path2._profile)
 
+    def test_transfer_from_different_endpoints(self):
+        # Create a bucket using a different endpoint (the default endpoint.)
+        boto3.resource("s3").create_bucket(Bucket="source-bucket")
+        source_path = ResourcePath("s3://source-bucket/file.txt")
+        source_path.write(b"123")
+        target_path = ResourcePath(f"s3://{self.netloc}/target.txt")
+        # Transfer from default endpoint to custom endpoint with custom
+        # profile.
+        target_path.transfer_from(source_path)
+        self.assertEqual(target_path.read(), b"123")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix an issue where S3ResourcePath.transfer_from(S3ResourcePath) would fail when the source and destination were using different S3 endpoints or sets of credentials.  We now intermediate the download ourselves, since boto3 does not support transfers between multiple endpoints.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
