### PR TITLE
DM-55517: Normalizing server_id to lowercase for dCache and XRootD server ID

### DIFF
--- a/python/lsst/resources/davutils.py
+++ b/python/lsst/resources/davutils.py
@@ -680,11 +680,11 @@ class DavClientPool:
         if server_id is None:
             # Create a generic webDAV client
             return DavClient(url, config, accepts_ranges)
-
-        if server_id.startswith("dCache/"):
+        server_id = server_id.lower()
+        if server_id.startswith("dcache"):
             # Create a client for a dCache webDAV server
             return DavClientDCache(url, config, accepts_ranges)
-        elif server_id.startswith("XrootD/"):
+        elif server_id.startswith("xrootd"):
             # Create a client for a XrootD webDAV server
             return DavClientXrootD(url, config, accepts_ranges)
         else:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`

Depending on the XRootD version, the server ID can be "XrootD/<version>" or "XRootD". The version was removed as of version 6.0.0 for improved security and the change to an uppercase "R" was done at the same time as a "typo fix".

At LANCS, `server_id` was found to be "XRootD".
At RAL, `server_id` was found to be "XrootD/v5.9.1".
At SLAC, `server_id` was found to be "XrootD/v5.8.4".

This change will accept either variant.
For consistency, `server_id` is now used in its lowercase form for dCache systems as well.
